### PR TITLE
Implemented bomb/defuse events.

### DIFF
--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -41,6 +41,14 @@ namespace DemoInfo
 		public event EventHandler<GrenadeEventArgs> ExplosiveNadeExploded;
 
 		public event EventHandler<NadeEventArgs> NadeReachedTarget;
+
+        public event EventHandler<BombEventArgs> BombBeginPlant;
+        public event EventHandler<BombEventArgs> BombAbortPlant;
+        public event EventHandler<BombEventArgs> BombPlanted;
+        public event EventHandler<BombEventArgs> BombDefused;
+        public event EventHandler<BombEventArgs> BombExploded;
+        public event EventHandler<BombDefuseEventArgs> BombBeginDefuse;
+        public event EventHandler<BombDefuseEventArgs> BombAbortDefuse;
 		#endregion
 
 		#region Information
@@ -65,7 +73,10 @@ namespace DemoInfo
 
 		public List<CSVCMsg_CreateStringTable> stringTables = new List<CSVCMsg_CreateStringTable>();
 
-		Entity ctTeamEntity, tTeamEntity;
+        Entity ctTeamEntity, tTeamEntity;
+
+        internal int bombSiteAEntityIndex = -1;
+        internal int bombSiteBEntityIndex = -1;
 
 		public int CTScore
 		{
@@ -212,6 +223,8 @@ namespace DemoInfo
 					if (entity.Properties.ContainsKey("m_angEyeAngles[0]"))
 						p.ViewDirectionY = (float)entity.Properties["m_angEyeAngles[0]"];
 
+                    if (entity.Properties.ContainsKey("m_bHasDefuser"))
+                        p.HasDefuseKit = (int)entity.Properties["m_bHasDefuser"] == 0;
 
 					if (p.IsAlive)
 					{
@@ -414,6 +427,48 @@ namespace DemoInfo
 			if (NadeReachedTarget != null)
 				NadeReachedTarget(this, args);
 		}
+
+        internal void RaiseBombBeginPlant(BombEventArgs args)
+        {
+            if (BombBeginPlant != null)
+                BombBeginPlant(this, args);
+        }
+
+        internal void RaiseBombAbortPlant(BombEventArgs args)
+        {
+            if (BombAbortPlant != null)
+                BombAbortPlant(this, args);
+        }
+
+        internal void RaiseBombPlanted(BombEventArgs args)
+        {
+            if (BombPlanted != null)
+                BombPlanted(this, args);
+        }
+
+        internal void RaiseBombDefused(BombEventArgs args)
+        {
+            if (BombDefused != null)
+                BombDefused(this, args);
+        }
+
+        internal void RaiseBombExploded(BombEventArgs args)
+        {
+            if (BombExploded != null)
+                BombExploded(this, args);
+        }
+
+        internal void RaiseBombBeginDefuse(BombDefuseEventArgs args)
+        {
+            if (BombBeginDefuse != null)
+                BombBeginDefuse(this, args);
+        }
+        internal void RaiseBombAbortDefuse(BombDefuseEventArgs args)
+        {
+            if (BombAbortDefuse != null)
+                BombAbortDefuse(this, args);
+        }
+
 		#endregion
 	}
 }

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -105,6 +105,20 @@ namespace DemoInfo
 		}
 	}
 
+    public class BombEventArgs : EventArgs
+    {
+        public Player Player { get; set; }
+
+        public char Site { get; set; }
+    }
+
+    public class BombDefuseEventArgs : EventArgs
+    {
+        public Player Player { get; set; }
+
+        public bool HasKit { get; set; }
+    }
+
 	public class Equipment
 	{
 		public EquipmentElement Weapon { get; set; }

--- a/DemoInfo/Player.cs
+++ b/DemoInfo/Player.cs
@@ -34,6 +34,8 @@ namespace DemoInfo
 
         public Team Team { get; set; }
 
+        public bool HasDefuseKit { get; set; }
+
 		/// <summary>
 		/// Copy this instance for multi-threading use. 
 		/// </summary>
@@ -51,7 +53,9 @@ namespace DemoInfo
 			me.ViewDirectionY = ViewDirectionY;
 			me.Disconnected = Disconnected;
 			me.Team = Team;
-
+            
+            me.HasDefuseKit = HasDefuseKit;
+            
 			if(Position != null)
 				me.Position = Position.Copy(); //Vector is a class, not a struct - thus we need to make it thread-safe. 
 

--- a/DemoInfo/Structs.cs
+++ b/DemoInfo/Structs.cs
@@ -73,6 +73,14 @@ namespace DemoInfo
 			}
 		}
 
+        public double Length
+        {
+            get
+            {
+                return Math.Sqrt(this.X * this.X + this.Y * this.Y + this.Z * this.Z);
+            }
+        }
+
         public static Vector Parse(BinaryReader reader)
         {
             return new Vector


### PR DESCRIPTION
Implements the following events:
- bomb_beginplant
- bomb_abortplant
- bomb_planted
- bomb_defused
- bomb_exploded
- bomb_begindefuse
- bomb_abortdefuse

also adds a Length property to Vector, and a HasKit property to Player.
I tested the events using a few demos from DHW2014. Everything seemed to work fine, although aborting the defuse never triggered.
It should be - there are definitely references in CPlantedC4's Think method that point to the event being emitted, so I don't know what's happening there.

To find the bomb locations I have to get the player resource entity, find the center of the bombsites, and compare that to the center of the entity that's given via the event. The bomb site index is cached.
