### PR TITLE
Fix protobuf-net nuget package location

### DIFF
--- a/DemoInfo/DemoInfo.csproj
+++ b/DemoInfo/DemoInfo.csproj
@@ -60,7 +60,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="protobuf-net">
-      <HintPath>..\..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
If you clone the repository and restore nuget packages, protobuf-net is located in a different location, preventing it from being compiled
This commit fixes that and allows the nuget restore and build to work
