### PR TITLE
System.Reflection.Emit magic activated

### DIFF
--- a/DemoInfo/DP/DemoPacketParser.cs
+++ b/DemoInfo/DP/DemoPacketParser.cs
@@ -6,17 +6,71 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using System.Reflection.Emit;
+using ProtoBuf;
 
 namespace DemoInfo.DP
 {
 	public static class DemoPacketParser
     {
-		private static IEnumerable<IMessageParser> Parsers = (
+		private static readonly IEnumerable<IMessageParser> Parsers = (
 			from type in Assembly.GetExecutingAssembly().GetTypes()
 			where type.GetInterfaces().Contains(typeof(IMessageParser))
 			let parser = (IMessageParser)type.GetConstructor(new Type[0]).Invoke(new object[0])
 			orderby -parser.Priority
 			select parser).ToArray();
+
+		private static readonly Func<Stream, int, IExtensible> ReadProtobufPacket;
+
+		static DemoPacketParser()
+		{
+			var dynmeth = new DynamicMethod("DemoPacketParser__GetPacketType",
+				typeof(IExtensible), new Type[] { typeof(Stream), typeof(int) });
+			var ilgen = dynmeth.GetILGenerator();
+
+			var deserializeMethod = typeof(Serializer).GetMethod("DeserializeWithLengthPrefix",
+				                        new Type[] { typeof(Stream), typeof(PrefixStyle) });
+
+			var elementList = new List<Type>();
+			foreach (var ele in
+				Enum.GetValues(typeof(SVC_Messages)).Cast<object>().Select(x => new { Code = (int)x, Name = x.ToString(), Prefix = "CSVCMsg_" })
+				.Concat(Enum.GetValues(typeof(NET_Messages)).Cast<object>().Select(x => new { Code = (int)x, Name = x.ToString(), Prefix = "CNETMsg_" }))
+				.Select(x => new { x.Code, Type = Assembly.GetExecutingAssembly().GetType("DemoInfo.Messages." + x.Prefix + x.Name.Substring(4)) })
+				.OrderBy(x => x.Code)) {
+				while (elementList.Count < ele.Code)
+					elementList.Add(null);
+				elementList.Add(ele.Type);
+			}
+
+			var defaultCase = ilgen.DefineLabel();
+			var jumpTable = elementList.Select(t => (t != null) ? ilgen.DefineLabel() : defaultCase).ToArray();
+			ilgen.Emit(OpCodes.Ldarg_1);
+			ilgen.Emit(OpCodes.Switch, jumpTable);
+			ilgen.Emit(OpCodes.Br, defaultCase);
+
+			//var endOfMethod = ilgen.DefineLabel();
+			for (int i = 0; i < elementList.Count; i++) {
+				if (elementList[i] != null) {
+					ilgen.MarkLabel(jumpTable[i]);
+					ilgen.Emit(OpCodes.Ldarg_0);
+					ilgen.Emit(OpCodes.Ldc_I4, (int)PrefixStyle.Base128);
+
+					ilgen.Emit(OpCodes.Tailcall);
+					ilgen.Emit(OpCodes.Call, deserializeMethod.MakeGenericMethod(elementList[i]));
+					//ilgen.Emit(OpCodes.Castclass, typeof(IExtensible));
+					//ilgen.Emit(OpCodes.Br, endOfMethod);
+					ilgen.Emit(OpCodes.Ret);
+				}
+			}
+			ilgen.MarkLabel(defaultCase);
+			ilgen.Emit(OpCodes.Ldnull);
+			//ilgen.Emit(OpCodes.Br_S, endOfMethod);
+			//ilgen.MarkLabel(endOfMethod);
+			ilgen.Emit(OpCodes.Ret);
+
+			ReadProtobufPacket = (Func<Stream, int, IExtensible>)dynmeth
+				.CreateDelegate(typeof(Func<Stream, int, IExtensible>));
+		}
 
 		public static void ParsePacket(Stream stream, DemoParser demo)
         {
@@ -26,27 +80,12 @@ namespace DemoInfo.DP
             {
                 int cmd = reader.ReadVarInt32();
 
-                Type toParse = null;
+				var result = ReadProtobufPacket(reader.BaseStream, cmd);
 
-                if (Enum.IsDefined(typeof(SVC_Messages), cmd))
-                {
-                    SVC_Messages msg = (SVC_Messages)cmd;
-                    toParse = Assembly.GetExecutingAssembly().GetType("DemoInfo.Messages.CSVCMsg_" + msg.ToString().Substring(4));
-                }
-                else if (Enum.IsDefined(typeof(NET_Messages), cmd))
-                {
-                    NET_Messages msg = (NET_Messages)cmd;
-                    toParse = Assembly.GetExecutingAssembly().GetType("DemoInfo.Messages.CNETMsg_" + msg.ToString().Substring(4));
-                }
-
-                if (toParse == null)  
-                {
+                if (result == null) {
                     reader.ReadBytes(reader.ReadVarInt32());
                     continue;
                 }
-
-
-                var result = reader.ReadProtobufMessage(toParse, ProtoBuf.PrefixStyle.Base128);
 
                 foreach (var parser in Parsers)
 					if (parser.TryApplyMessage(result, demo) && (parser.Priority > 0))


### PR DESCRIPTION
Before:

```
    3508     2353    5742735 System.Type:get_IsSystemType ()
    5714     2099    2603928 System.Type:IsSubclassOf (System.Type)
```

After:

```
     808      536    1268117 System.Type:get_IsSystemType ()
    1509      569     634531 System.Type:IsSubclassOf (System.Type)
   21450      123     267484 (wrapper dynamic-method) object:DemoPacketParser__GetPacketType (System.IO.Stream,int)
```

This means: >3s vs 123ms (if you just look at their self times, otherwise it's up to 7s). Not too bad.

And omg looks like protobuf is incredibly slow.

TODO: Find out how Microsoft's .NET reacts to this (for you, @moritzuehling)
TODO: Find out if the generated code is verifiable (it probably isn't), decide if the performance penalty is worth verifiability (it probably is) and then make it generate verifiable code.

So don't merge yet.
