### PR TITLE
Added nuget install script that excludes us from Strong Name verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ script:
   - python ci/brofiler.py verify
   - python ci/brofiler.py run
 after_success:
-  - "[ \"$TRAVIS_PULL_REQUEST\" = \"false\" ] && [ \"$TRAVIS_BRANCH\" = \"master\" ] && sed -i \"s/<\\/version>/-ci$(date +%s)-$(git rev-parse --short HEAD)<\\/version>/\" DemoInfo.nuspec && nuget pack DemoInfo.nuspec && nuget push *.nupkg"
+  - "[ \"$TRAVIS_PULL_REQUEST\" = \"false\" ] && [ \"$TRAVIS_BRANCH\" = \"master\" ] && sed -i \"s/<\\/version>/-ci$(date +%s)-$(git rev-parse --short HEAD)<\\/version>/\" DemoInfo.nuspec && sed -i \"s/<\\/files>/<file src="nuget\\/Install.ps1" target="tools" \\/><\\/files>/\" DemoInfo.nuspec && nuget pack DemoInfo.nuspec && nuget push *.nupkg"
 after_script:
   - python ci/brofiler.py cleanup

--- a/DemoInfo.nuspec
+++ b/DemoInfo.nuspec
@@ -9,8 +9,8 @@
     <projectUrl>https://github.com/moritzuehling/demoinfo-public/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is a C#-Library that makes reading CS:GO-Demos and analyzing them easier.</description>
-    <releaseNotes>Initial nuget release.</releaseNotes>
-    <tags>csgo demoinfo demoinfo-public</tags>
+    <releaseNotes>This is an automatic prerelease build of DemoInfo. The assembly is delay-signed (https://msdn.microsoft.com/en-us/library/t07a3dye.aspx), so the install script calls the Strong Name tool sn.exe to turn off verification for DemoInfo.dll. This means that an attacker could modify the assembly and it'll still show up as validly signed. Once you no longer need to use prereleases of DemoInfo on your machine, just run 'sn -Vu DemoInfo.dll' to close this security gap. If you copy the project to another machine, please either reinstall the package or run 'sn -Vr DemoInfo.dll' to manually add the assembly to the skip list. To clarify: None of this is relevant if you just use the normal releases as they carry a proper signature.</releaseNotes>
+    <tags>csgo demoinfo demoinfo-public demoinfogo</tags>
   </metadata>
   <files>
     <file src="DemoInfo/bin/Release/DemoInfo.dll" target="lib/net45" />

--- a/nuget/Install.ps1
+++ b/nuget/Install.ps1
@@ -1,0 +1,11 @@
+param($installPath, $toolsPath, $package, $project)
+
+# We *could* create a Uninstall.ps1 that automatically removes the assembly from the skip list.
+# However, imagine the following scenario: User installs this twice, into projects A and B.
+# Then they remove it from project A and work on project B.
+# Result: B won't run because uninstalling DemoInfo from A removed the assembly from the skip list.
+# So we have no choice, users have to remove it manually.
+# While assemblies on the skip list are a security issue, they're not a huge one. Security is
+# effectively reduced to straight up loading an unsigned assembly, so we lose nothing.
+Host-Write "You are using a prerelease version of DemoInfo. These are built automatically by travis and therefore delay-signed. Because of that, .NET would reject the assembly, so I'm adding it to the verification skip list. You can remove it using 'sn -Vu DemoInfo.dll'. For more information, please have a look at the nuget release notes."
+sn -Vr "$installPath\DemoInfo.dll"


### PR DESCRIPTION
Apparently .NET straight up rejects delay signed assemblies even in full trust environments unless you exclude them manually using the Strong Name tool.

Todo:

- [ ] Test [this](http://lolz.ehvag.de/DemoInfo.1.1.0.nupkg) on windows (hfhf @moritzuehling)