### PR TITLE
UnsafeBitStream will never leak memory again.

### DIFF
--- a/DemoInfo/BitStream/UnsafeBitStream.cs
+++ b/DemoInfo/BitStream/UnsafeBitStream.cs
@@ -35,11 +35,26 @@ namespace DemoInfo.BitStreamImpl
 			Offset = SLED * 8;
 		}
 
+		~UnsafeBitStream()
+		{
+			Dispose();
+		}
+
 		void IDisposable.Dispose()
 		{
-			PBuffer = (byte*)IntPtr.Zero.ToPointer(); // null it out
-			HBuffer.Free();
-			Buffer = null;
+			Dispose();
+			GC.SuppressFinalize(this);
+		}
+
+		private void Dispose()
+		{
+			var nullptr = (byte*)IntPtr.Zero.ToPointer();
+			if (PBuffer != nullptr) {
+				// GCHandle docs state that Free() must only be called once.
+				// So we use PBuffer to ensure that.
+				PBuffer = nullptr;
+				HBuffer.Free();
+			}
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
You have to dispose the DemoParser anyways because your event handlers could produce GC cycles if they reference the parser.

But just in case someone else copies our MIT-licensed bitstream or something, having an implementation that NEVER leaks memory is better, right?