### PR TITLE
added PlayerBind and PlayerDisconnect events

### DIFF
--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -231,6 +231,11 @@ namespace DemoInfo.DP.Handler
 				break;
 			case "player_disconnect":
 				data = MapData(eventDescriptor, rawEvent);
+
+				PlayerDisconnectEventArgs disconnect = new PlayerDisconnectEventArgs();
+				disconnect.Player = parser.Players[(int)data["userid"]];
+				parser.RaisePlayerDisconnect(disconnect);
+
 				int toDelete = (int)data["userid"];
 				for (int i = 0; i < parser.RawPlayers.Length; i++) {
 

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -198,6 +198,18 @@ namespace DemoInfo
 		/// Hint: Only occurs in GOTV-demos. 
 		/// </summary>
 		public event EventHandler<PlayerHurtEventArgs> PlayerHurt;
+
+
+		/// <summary>
+		/// Occurs when the player object is first updated to reference all the necessary information
+		/// Hint: Event will be raised when any player with a SteamID connects, not just PlayingParticipants
+		/// </summary>
+		public event EventHandler<PlayerBindEventArgs> PlayerBind;
+
+		/// <summary>
+		/// Occurs when a player disconnects from the server. 
+		/// </summary>
+		public event EventHandler<PlayerDisconnectEventArgs> PlayerDisconnect;
 		#endregion
 
 		/// <summary>
@@ -508,8 +520,11 @@ namespace DemoInfo
 				int id = rawPlayer.UserID;
 
 				if (PlayerInformations[i] != null) { //There is an good entity for this
-					if (!Players.ContainsKey(id))
+					bool newplayer = false;
+					if (!Players.ContainsKey(id)){
 						Players[id] = PlayerInformations[i];
+						newplayer = true;
+					}
 
 					Player p = Players[id];
 					p.Name = rawPlayer.Name;
@@ -519,6 +534,12 @@ namespace DemoInfo
 
 					if (p.IsAlive) {
 						p.LastAlivePosition = p.Position.Copy();
+					}
+
+					if (newplayer && p.SteamID != 0){
+						PlayerBindEventArgs bind = new PlayerBindEventArgs();
+						bind.Player = p;
+						RaisePlayerBind(bind);
 					}
 				}
 			}
@@ -1130,6 +1151,18 @@ namespace DemoInfo
 		{
 			if (PlayerHurt != null)
 				PlayerHurt(this, hurt);
+		}
+
+		internal void RaisePlayerBind(PlayerBindEventArgs bind)
+		{
+			if (PlayerBind != null)
+				PlayerBind(this, bind);
+		}
+
+		internal void RaisePlayerDisconnect(PlayerDisconnectEventArgs bind)
+		{
+			if (PlayerDisconnect != null)
+				PlayerDisconnect(this, bind);
 		}
 
 		internal void RaisePlayerTeam(PlayerTeamEventArgs args)

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -241,6 +241,16 @@ namespace DemoInfo
 		public Hitgroup Hitgroup { get; set; }
 	}
 
+	public class PlayerBindEventArgs : EventArgs
+	{
+		public Player Player {get; set; }
+	}
+
+	public class PlayerDisconnectEventArgs : EventArgs
+	{
+		public Player Player {get; set; }
+	}
+
 	public class Equipment
 	{
 		internal int EntityID { get; set; }


### PR DESCRIPTION
I made the name PlayerBind instead of PlayerConnect to reflect the fact that it's called when the data is bound rather than when the player connects.  Perhaps it would be better to raise the event when a player joins a team so that spectators/admins etc aren't included, but I thought that would be getting further away from the idea of a playerconnect type of event.

The PlayerDisconnect event is raised right before the Player object is deleted.  It worked for me so far, but I don't know the program or C# events well enough to know if this can potentially cause problems.