### PR TITLE
use UTF-8 instead of ANSI for players name

### DIFF
--- a/DemoInfo/Helper.cs
+++ b/DemoInfo/Helper.cs
@@ -14,7 +14,7 @@ namespace DemoInfo
 	{
 		public static string ReadCString(this BinaryReader reader, int length)
 		{
-			return ReadCString(reader, length, Encoding.Default);
+			return ReadCString(reader, length, Encoding.UTF8);
 		}
 
 		public static int ReadInt32SwapEndian(this BinaryReader reader)


### PR DESCRIPTION
Players may have nicknames with UTF-8 characters which result to strange name with ANSI encoding.
If you don't see any problems with that it will be nice to encode it in UTF-8.