### PR TITLE
implemented ReadSignedVarInt #68

### DIFF
--- a/DemoInfo/BitStream/BitStreamUtil.cs
+++ b/DemoInfo/BitStream/BitStreamUtil.cs
@@ -129,6 +129,12 @@ namespace DemoInfo
 			return result;
 		}
 
+		public static uint ReadSignedVarInt(this IBitStream bs)
+		{
+			uint result = bs.ReadVarInt();
+			return (uint)((result >> 1) ^ -(result & 1));
+		}
+
 		public static int ReadProtobufVarIntStub(IBitStream reader)
 		{
 			byte b = 0x80;

--- a/DemoInfo/DP/Handler/PropDecoder.cs
+++ b/DemoInfo/DP/Handler/PropDecoder.cs
@@ -38,8 +38,7 @@ namespace DemoInfo.DP.Handler
 				if (prop.Flags.HasFlagFast(SendPropertyFlags.Unsigned)) {
 					return (int)reader.ReadVarInt();
 				} else {
-					Trace.WriteLine("signed varints are not implemented. BAAAAAAD.", "PropDecoder:DecodeInt()");
-					return (int)reader.ReadVarInt();
+					return (int)reader.ReadSignedVarInt();
 				}
 			} else {
 				if (prop.Flags.HasFlagFast(SendPropertyFlags.Unsigned)) {


### PR DESCRIPTION
I'm not sure, but it seems that ATM only this [method] (https://github.com/csgo-data/demoinfogo-mirror/blob/master/demofilebitbuf.h#L231) is used.
From the original [code] (https://github.com/csgo-data/demoinfogo-mirror/blob/master/demofilebitbuf.h#L90), the method received an unint made with ReadVarInt() and make some bitwise operations on the final result.
Correct me if I'm wrong but it should works the same with C#?