### PR TITLE
added revolver weapon

### DIFF
--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -142,7 +142,9 @@ namespace DemoInfo.DP.Handler
 				kill.Headshot = (bool)data["headshot"];
 				kill.Weapon = new Equipment((string)data["weapon"], (string)data["weapon_itemid"]);
 
-				if (kill.Killer != null && kill.Weapon.Class != EquipmentClass.Grenade && kill.Killer.Weapons.Any() && kill.Weapon.Weapon != EquipmentElement.World) {
+				if (kill.Killer != null && kill.Weapon.Class != EquipmentClass.Grenade
+						&& kill.Weapon.Weapon != EquipmentElement.Revolver
+						&& kill.Killer.Weapons.Any() && kill.Weapon.Weapon != EquipmentElement.World) {
 					#if DEBUG
 					if(kill.Weapon.Weapon != kill.Killer.ActiveWeapon.Weapon)
 						throw new InvalidDataException();

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -539,6 +539,9 @@ namespace DemoInfo
 				case "usp_silencer_off":
 					weapon = EquipmentElement.USP;
 					break;
+				case "revolver":
+					weapon = EquipmentElement.Revolver;
+					break;
 				case "scar17"://These crash the game when given via give weapon_[mp5navy|...], and cannot be purchased ingame.
 				case "sg550"://yet the server-classes are networked, so I need to resolve them. 
 				case "mp5navy": 
@@ -572,6 +575,7 @@ namespace DemoInfo
 		Tec9 = 7,
 		CZ = 8,
 		USP = 9,
+		Revolver = 10,
 
 		//SMGs
 		MP7 = 101,


### PR DESCRIPTION
It seems that demos return "deagle" instead of "revolver" on weapon_fire events (not on player_killed events) and the player's active weapon is always "deagle".
I added the revolver reference but I had to add a check to avoid the active weapon update when it's the revolver.