### PR TITLE
revert surrender order

### DIFF
--- a/DemoInfo/Structs.cs
+++ b/DemoInfo/Structs.cs
@@ -435,13 +435,13 @@ namespace DemoInfo
 		/// </summary>
 		GameStart,
 		/// <summary>
-		/// CTs Surrender
-		/// </summary>
-		CTSurrender,
-		/// <summary>
 		/// Terrorists Surrender
 		/// </summary>
-		TerroristsSurrender
+		TerroristsSurrender,
+		/// <summary>
+		/// CTs Surrender
+		/// </summary>
+		CTSurrender
 	};
 
 	public enum RoundMVPReason


### PR DESCRIPTION
I tested with more demos and it seems that sometimes the field "reason" is inverted but not the field "message".

Wrong:

    round_end
    {
        winner: 3 
        reason: 17 
        message: #SFUI_Notice_Terrorists_Surrender 
        legacy: 0 
     }

OK:

    round_end
    {
        winner: 3 
        reason: 16 
        message: #SFUI_Notice_Terrorists_Surrender 
    }

The order was right, I reverted it.