### PR TITLE
Removed outdated/misleading TODO section from README.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Since no Windows machines are involved in any part of the development process, w
 Refer to [this guide](https://github.com/moritzuehling/demostatistics-generator/blob/master/README.md#usage-of-demoinfo-public). There is also an example-project where you can see the parser in action!
 
 ##Features 
-###ToDo
-A list of which game-events are implemented and which aren't can be found [here](https://gist.github.com/moritzuehling/bcc71f306249f0d85628). 
-
-###Done
 
 * Get Informations about each player at any point in time: 
  * Name


### PR DESCRIPTION
Users can infer from the Features section if the functionality they require is implemented, so the TODO section is not only outdated and wrong, but also redundant and obsolete.