### PR TITLE
add round_announce_match_start event

### DIFF
--- a/DemoInfo/DP/Handler/GameEventHandler.cs
+++ b/DemoInfo/DP/Handler/GameEventHandler.cs
@@ -109,6 +109,9 @@ namespace DemoInfo.DP.Handler
 			if (eventDescriptor.Name == "begin_new_match")
 				parser.RaiseMatchStarted ();
 
+			if (eventDescriptor.Name == "round_announce_match_start")
+				parser.RaiseRoundAnnounceMatchStarted();
+
 			if (eventDescriptor.Name == "round_freeze_end")
 				parser.RaiseFreezetimeEnded ();
 

--- a/DemoInfo/DemoParser.cs
+++ b/DemoInfo/DemoParser.cs
@@ -42,6 +42,11 @@ namespace DemoInfo
 		public event EventHandler<MatchStartedEventArgs> MatchStarted;
 
 		/// <summary>
+		/// Occurs when the first round of a new match start "round_announce_match_start"
+		/// </summary>
+		public event EventHandler<RoundAnnounceMatchStartedEventArgs> RoundAnnounceMatchStarted;
+
+		/// <summary>
 		/// Occurs when round starts, on the round_start event of the demo. Usually the players haven't spawned yet, but have recieved the money for the next round. 
 		/// </summary>
 		public event EventHandler<RoundStartedEventArgs> RoundStart;
@@ -1122,6 +1127,12 @@ namespace DemoInfo
 		{
 			if (MatchStarted != null)
 				MatchStarted(this, new MatchStartedEventArgs());
+		}
+
+		internal void RaiseRoundAnnounceMatchStarted()
+		{
+			if (RoundAnnounceMatchStarted != null)
+				RoundAnnounceMatchStarted(this, new RoundAnnounceMatchStartedEventArgs());
 		}
 
 		internal void RaiseWinPanelMatch()

--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -115,6 +115,10 @@ namespace DemoInfo
 	{
 	}
 
+	public class RoundAnnounceMatchStartedEventArgs : EventArgs
+	{
+	}
+
 	public class RoundEndedEventArgs : EventArgs
 	{
 		public RoundEndReason Reason { get; set; }


### PR DESCRIPTION
I added it because some demos doesn't have the event "begin_new_match" and "round_announce_match_start" occurs just after it.