### PR TITLE
Added molotov_projectile

### DIFF
--- a/DemoInfo/Events.cs
+++ b/DemoInfo/Events.cs
@@ -475,6 +475,7 @@ namespace DemoInfo
 					break;
 				case "molotov":
 				case "molotovgrenade":
+				case "molotov_projectile":
 					weapon = EquipmentElement.Molotov;
 					break;
 				case "mp7":


### PR DESCRIPTION
Added molotov_projectile to MapEquipment so that e.Weapon registers as Molotov instead of Knife when a player is hit by the projectile.  