### PR TITLE
fix end reason number

### DIFF
--- a/DemoInfo/Structs.cs
+++ b/DemoInfo/Structs.cs
@@ -372,7 +372,7 @@ namespace DemoInfo
 		/// <summary>
 		/// Target Successfully Bombed!
 		/// </summary>
-		TargetBombed = 0,        
+		TargetBombed = 1,
 		/// <summary>
 		/// The VIP has escaped.
 		/// </summary>


### PR DESCRIPTION
It looks like the field "end reason" doesn't start at 0 but 1.
I tested it with multiple demos and the reason is now the right one.
The other possibility is that a new end reason with a value "0" has been added but I never had it.